### PR TITLE
Fixes bug when fetching times and converts print to warnings

### DIFF
--- a/model_catalogs/model_catalogs.py
+++ b/model_catalogs/model_catalogs.py
@@ -2,6 +2,8 @@
 Everything dealing with the catalogs.
 """
 
+import warnings
+
 from pathlib import Path
 
 import cf_xarray  # noqa
@@ -245,8 +247,9 @@ def find_datetimes(source, find_start_datetime, find_end_datetime, override=Fals
             )
             ds.close()
         except OSError:
-            print(
-                f"Model {source.cat.name} with timing {source.name} cannot connect to server."
+            warnings.warn(
+                f"Model {source.cat.name} with timing {source.name} cannot connect to server.",
+                RuntimeWarning,
             )
             return None, None
 
@@ -329,7 +332,7 @@ def find_datetimes(source, find_start_datetime, find_end_datetime, override=Fals
             # want last file
             if source.name == "hindcast":
                 norf = "n"
-            elif source.name == "nowcast":
+            elif source.name in ("nowcast", "forecast"):
                 norf = "f"
             end_datetime = str(mc.get_dates_from_ofs(filelocs, filetype, norf, "last"))
         else:


### PR DESCRIPTION
To reduce unnecessary print statements from appearing in clients, this
commit updates the print statement for a cautionary state to use a
standard python Warning which can be handled (or ignored) by the client.

This commit also fixes a bug that causes a NameError to be raised.

## Pull Request Reminders

- [x] Any tests that connect to model servers are marked with the `--runslow` decorator and won't be run by GitHub Actions. You should run these locally with `pytest --runslow`.
- [ ] Make sure the notebooks in the `docs` directory all run.
- [x] Add tests for the new functionality.
