### PR TITLE
now can query urlpath from transform catalogs

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,6 +1,14 @@
 :mod:`What's New`
 ----------------------------
 
+v0.3.0 (unreleased)
+===================
+
+* Can now query even the transform catalogs for the target `urlpath` (see future update in docs)
+* Can explicitly follow the transform catalog to the target catalog with `cat.follow_target()`.
+* `select_date_range()` now explicitly replaces the `urlpath` of the target when the function is run rather than later when `to_dask()` is run.
+
+
 v0.2.0 (August 24, 2022)
 ========================
 


### PR DESCRIPTION
urlpath is not an arg for the transform catalogs, but users want to be able to see what they are for the target source. Now the transform is followed through to the target with `cat.follow_target()` which also sets the urlpath attribute in the target source from the orig source. This is run in mc.setup() and mc.find_availability so that it is always updated. mc.select_date_range() runs `cat.update_urlpath` to bring the newly discovered urlpath list to the target and makes it discoverable like in the other cases too with `source.urlpath`.

## Pull Request Reminders

- [ ] Make sure the notebooks in the `docs` directory all run.
- [ ] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work. If not already present, add a new section at the top of the document stating "[expected new version number] (unreleased)", for example: "v0.7.3 (unreleased)"
