### PR TITLE
Fixes bug with applying standard names

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -10,6 +10,7 @@ v0.4.0 (unreleased)
 * Updated many details in `Model Aggregations <https://model-catalogs.readthedocs.io/en/latest/aggregations.html#>`_ page of docs.
 * Package now available on conda-forge!
 * `source.follow_target()` was renamed `source.target`. It exposes the original catalog information, which is the target of the source transform. It is a property now instead of a method.
+* Fixed bug when applying `standard_name` attributes to coordinate variables.
 
 
 v0.3.0 (September 9, 2022)

--- a/model_catalogs/process.py
+++ b/model_catalogs/process.py
@@ -170,7 +170,7 @@ def add_attributes(ds, metadata: Optional[dict] = None):
             if not isinstance(var_names, list):
                 var_names = [var_names]
             for var_name in var_names:
-                if var_name in ds.data_vars:
+                if var_name in ds.variables:
                     ds[var_name].attrs["standard_name"] = stan_name
 
     # # Run code to find vertical coordinates

--- a/model_catalogs/process.py
+++ b/model_catalogs/process.py
@@ -228,7 +228,9 @@ def add_attributes(ds, metadata: Optional[dict] = None):
     # Some datasets like GFS have multiple time coordinates for different phenomena like
     # precipitation accumulation vs winds vs surface albedo average.
     if (
-        "T" in metadata["axis"]
+        metadata is not None
+        and "axis" in metadata
+        and "T" in metadata["axis"]
         and isinstance(metadata["axis"]["T"], list)
         and len(metadata["axis"]["T"]) > 1
     ):
@@ -236,7 +238,7 @@ def add_attributes(ds, metadata: Optional[dict] = None):
             if ds[time_var].dtype == "float64":
                 ds = xr.decode_cf(ds, decode_times=True)
                 break
-    elif ds.cf["T"].dtype == "float64":
+    elif "T" in ds.cf and ds.cf["T"].dtype == "float64":
         ds = xr.decode_cf(ds, decode_times=True)
 
     if metadata is not None and "formula_terms" in metadata:

--- a/model_catalogs/tests/test_catalogs.py
+++ b/model_catalogs/tests/test_catalogs.py
@@ -9,11 +9,15 @@ them instead.
 
 import warnings
 
+import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 import yaml
 
 import model_catalogs as mc
+
+from model_catalogs import process
 
 
 def test_setup():
@@ -318,3 +322,28 @@ def test_urlpath_after_select():
     ]
 
     assert source.urlpath == known_filenames
+
+
+def test_setting_std_name():
+    """Test updating standard name metadata attributes."""
+    lon = xr.DataArray(
+        data=np.arange(360), dims=("lon",), attrs={"units": "degrees_east"}
+    )
+    lat = xr.DataArray(
+        data=np.arange(-90, 90), dims=("lat",), attrs={"units": "degrees_north"}
+    )
+    temp = xr.DataArray(
+        data=np.arange(360 * 180).reshape(180, 360),
+        dims=("lat", "lon"),
+        attrs={"units": "degrees_C"},
+    )
+    ds = xr.Dataset({"lon": lon, "lat": lat, "temp": temp})
+    metadata = {
+        "standard_names": {
+            "longitude": ["lon"],
+            "latitude": ["lat"],
+        }
+    }
+    ds = process.add_attributes(ds, metadata=metadata)
+    assert ds["lon"].attrs["standard_name"] == "longitude"
+    assert ds["lat"].attrs["standard_name"] == "latitude"


### PR DESCRIPTION
For models that don't include standard names on the coordinate variables like GFS, we want to be able to set standard_names on them. This commit updates the `add_attributes` method to ensure that even coordinate variables can have the standard name set properly.

## Pull Request Reminders

- [x] Make sure the notebooks in the `docs` directory all run.
- [x] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work. If not already present, add a new section at the top of the document stating "[expected new version number] (unreleased)", for example: "v0.7.3 (unreleased)"
